### PR TITLE
check_snmp_int.pl new options

### DIFF
--- a/plugins/check_snmp_int.pl
+++ b/plugins/check_snmp_int.pl
@@ -35,7 +35,7 @@ my $descr_table        = '1.3.6.1.2.1.2.2.1.2';
 my $name_table         = '1.3.6.1.2.1.31.1.1.1.1';
 my $alias_table        = '.1.3.6.1.2.1.31.1.1.1.18';
 my $oper_table         = '1.3.6.1.2.1.2.2.1.8.';
-my $admin_table        = '1.3.6.1.2.1.2.2.1.7.';
+my $admin_table        = '1.3.6.1.2.1.2.2.1.7';
 my $speed_table        = '1.3.6.1.2.1.2.2.1.5.';
 my $speed_table_64     = '1.3.6.1.2.1.31.1.1.1.15.';
 my $in_octet_table     = '1.3.6.1.2.1.2.2.1.10.';
@@ -60,20 +60,22 @@ my %status = (
 # Globals
 
 # Standard options
-my $o_host    = undef;    # hostname
-my $o_port    = 161;      # port
-my $o_descr   = undef;    # description filter
-my $o_help    = undef;    # wan't some help ?
-my $o_admin   = undef;    # admin status instead of oper
-my $o_inverse = undef;    # Critical when up
-my $o_dormant = undef;    # Dormant state is OK
-my $o_down    = undef;    # Down state is OK
-my $o_verb    = undef;    # verbose mode
-my $o_version = undef;    # print version
-my $o_noreg   = undef;    # Do not use Regexp for name
-my $o_short   = undef;    # set maximum of n chars to be displayed
-my $o_label   = undef;    # add label before speed (in, out, etc...).
-my $o_weather = undef;    # output "weathermap" data for NagVis
+my $o_host              = undef;    # hostname
+my $o_port              = 161;      # port
+my $o_descr             = undef;    # description filter
+my $o_help              = undef;    # wan't some help ?
+my $o_admin             = undef;    # admin status instead of oper
+my $o_inverse           = undef;    # Critical when up
+my $o_dormant           = undef;    # Dormant state is OK
+my $o_down              = undef;    # Down state is OK
+my $o_ignore_admindown  = undef;    # Ignore interfaces in admin down state
+my $o_ignore_emptyalias = undef;    # ignore interfaces with empty alias (interface description string)
+my $o_verb              = undef;    # verbose mode
+my $o_version           = undef;    # print version
+my $o_noreg             = undef;    # Do not use Regexp for name
+my $o_short             = undef;    # set maximum of n chars to be displayed
+my $o_label             = undef;    # add label before speed (in, out, etc...).
+my $o_weather           = undef;    # output "weathermap" data for NagVis
 
 # Performance data options
 my $o_perf  = undef;      # Output performance data
@@ -224,6 +226,10 @@ sub help {
    Dormant state is an OK state
 --down
    Down state is an OK state
+--ign-admindown
+   Ignore interfaces in Admin down state
+--ign-emptyalias
+   Ignore interfaces having empty alias (port description)
 -o, --octetlength=INTEGER
   max-size of the SNMP message, usefull in case of Too Long responses.
   Be carefull with network filters. Range 484 - 65535, default are
@@ -358,7 +364,9 @@ sub check_options {
         'dormant'       => \$o_dormant,
         'down'          => \$o_down,
         'W'             => \$o_weather,
-        'weather'       => \$o_weather
+        'weather'       => \$o_weather,
+        'ign-admindown' => \$o_ignore_admindown,
+        'ign-emptyalias' => \$o_ignore_emptyalias,
     );
     if (defined($o_help))    { help();      exit $ERRORS{"UNKNOWN"} }
     if (defined($o_version)) { p_version(); exit $ERRORS{"UNKNOWN"} }
@@ -489,6 +497,14 @@ sub check_options {
         print_usage();
         exit $ERRORS{"UNKNOWN"};
     }
+
+    #### check if --admin and --ign-admindown are put together.
+    #### --ign-admindown expects the open_state of the port to be used
+    if (defined($o_ignore_admindown) && defined($o_admin)) {
+        print "ERROR: --ign-admindown and -a are mutually exclusive. Please select only one.\n\n";
+        print_usage();
+        exit $ERRORS{"UNKNOWN"};
+    }
 }
 
 ########## MAIN #######
@@ -616,6 +632,31 @@ if (defined($o_highperf)) {
     $in_octet_table  = $in_octet_table_64;
 }
 
+# If --ign-admindown is set, we need to have admin status table
+my $admin_status_table;
+if (defined($o_ignore_admindown)) {
+    $admin_status_table = $session->get_table(Baseoid => $admin_table);
+
+    if (!defined($admin_status_table)) {
+        printf("ERROR: Admin status table : %s.\n", $session->error);
+        $session->close;
+        exit $ERRORS{"UNKNOWN"};
+    }
+}
+
+# If --ign-emptyalias is set, we need to have aliases table
+my $interfaces_aliases;
+if (defined($o_ignore_emptyalias)) {
+    $interfaces_aliases = $session->get_table(Baseoid => $alias_table);
+
+    if (!defined($interfaces_aliases)) {
+        printf("ERROR: Alias status table : %s.\n", $session->error);
+        $session->close;
+        exit $ERRORS{"UNKNOWN"};
+    }
+}
+
+
 # Select interface by regexp of exact match
 # and put the oid to query in an array
 
@@ -623,12 +664,30 @@ verb("Filter : $o_descr");
 foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
     verb("OID : $key, Desc : $$resultat{$key}");
 
+    my $ignore = 0;
+    my $prefix = $query_table . ".";
+    my ($ifindex) = $key =~ /$prefix(\d+)$/;
+
+    # if ign-admindown is set, check the ifIndex against admin status
+    if (defined($o_ignore_admindown)) {
+	my $index = $admin_table . "." . $ifindex;
+        my $admstatus = $$admin_status_table{$index};
+        $ignore = 1 if ($admstatus == 2);
+    }
+
+    # if ign-emptyalias is set, check the ifIndex against alias string
+    if (defined($o_ignore_emptyalias)) {
+	my $index = $alias_table . "." . $ifindex;
+        my $alias = $$interfaces_aliases{$index};
+        $ignore = 1 if ($alias eq "");
+    }
+
     # test by regexp or exact match
     my $test
         = defined($o_noreg)
         ? $$resultat{$key} eq $o_descr
         : $$resultat{$key} =~ /$o_descr/;
-    if ($test) {
+    if ($test && !$ignore) {
 
         # get the index number of the interface
         my @oid_list = split(/\./, $key);
@@ -645,7 +704,7 @@ foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
             # Get rid of special caracters (specially for Windows)
             $descr[$num_int] =~ s/[[:cntrl:]]//g;
             # put the admin or oper oid in an array
-            $oids[$num_int]= defined ($o_admin) ? $admin_table . $tindex[$num_int] 
+            $oids[$num_int]= defined ($o_admin) ? $admin_table . "." . $tindex[$num_int]
 			: $oper_table . $tindex[$num_int];
 
             # Put the performance oid 
@@ -724,7 +783,7 @@ for (my $i = 0; $i < $num_int; $i++) {
     # Get the status of the current interface
     my $int_status
         = defined($o_admin)
-        ? $$result{ $admin_table . $tindex[$i] }
+        ? $$result{ $admin_table . "." . $tindex[$i] }
         : $$result{ $oper_table . $tindex[$i] };
 
     # Make the bandwith & error checks if necessary
@@ -976,6 +1035,7 @@ for (my $i = 0; $i < $num_int; $i++) {
             $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_out_discard'=" . $$result{ $oid_perf_outdisc[$i] } . "c ";
         }
         if (defined($o_perfs)) {
+	    my $speed_real = "" unless (defined($speed_real));
             $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_speed_bps'=" . $speed_real . " ";
         }
         if (defined($o_weather) && $usable_data == 1) {

--- a/plugins/check_snmp_int.pl
+++ b/plugins/check_snmp_int.pl
@@ -78,42 +78,42 @@ my $o_label             = undef;    # add label before speed (in, out, etc...).
 my $o_weather           = undef;    # output "weathermap" data for NagVis
 
 # Performance data options
-my $o_perf  = undef;      # Output performance data
-my $o_perfe = undef;      # Output discard/error also in perf data
-my $o_perfs = undef;      # include speed in performance output (-S)
-my $o_perfp = undef;      # output performance data in % of max speed (-y)
-my $o_perfr = undef;      # output performance data in bits/s or Bytes/s (-Y)
+my $o_perf  = undef;                # Output performance data
+my $o_perfe = undef;                # Output discard/error also in perf data
+my $o_perfs = undef;                # include speed in performance output (-S)
+my $o_perfp = undef;                # output performance data in % of max speed (-y)
+my $o_perfr = undef;                # output performance data in bits/s or Bytes/s (-Y)
 
 # Speed/error checks
-my $o_checkperf     = undef;    # checks in/out/err/disc values
-my $o_delta         = 300;      # delta of time of perfcheck (default 5min)
-my $o_ext_checkperf = undef;    # extended perf checks (+error+discard)
-my $o_warn_opt      = undef;    # warning options
-my $o_crit_opt      = undef;    # critical options
-my $o_kbits         = undef;    # Warn and critical in Kbits instead of KBytes
-my @o_warn          = undef;    # warning levels of perfcheck
-my @o_crit          = undef;    # critical levels of perfcheck
-my $o_highperf      = undef;    # Use 64 bits counters
-my $o_meg           = undef;    # output in MBytes or Mbits (-M)
-my $o_gig           = undef;    # output in GBytes or Gbits (-G)
-my $o_prct          = undef;    # output in % of max speed  (-u)
-my $o_use_ifname    = undef;    # use IF-MIB::ifName instead of IF-MIB::ifDescr
-my $o_use_ifalias   = undef;    # use IF-MIB::ifAlias instead of IF-MIB::ifDescr
+my $o_checkperf     = undef;        # checks in/out/err/disc values
+my $o_delta         = 300;          # delta of time of perfcheck (default 5min)
+my $o_ext_checkperf = undef;        # extended perf checks (+error+discard)
+my $o_warn_opt      = undef;        # warning options
+my $o_crit_opt      = undef;        # critical options
+my $o_kbits         = undef;        # Warn and critical in Kbits instead of KBytes
+my @o_warn          = undef;        # warning levels of perfcheck
+my @o_crit          = undef;        # critical levels of perfcheck
+my $o_highperf      = undef;        # Use 64 bits counters
+my $o_meg           = undef;        # output in MBytes or Mbits (-M)
+my $o_gig           = undef;        # output in GBytes or Gbits (-G)
+my $o_prct          = undef;        # output in % of max speed  (-u)
+my $o_use_ifname    = undef;        # use IF-MIB::ifName instead of IF-MIB::ifDescr
+my $o_use_ifalias   = undef;        # use IF-MIB::ifAlias instead of IF-MIB::ifDescr
 
-my $o_timeout = undef;          # Timeout (Default 5)
+my $o_timeout = undef;              # Timeout (Default 5)
 
 # SNMP Message size parameter (Makina Corpus contrib)
 my $o_octetlength = undef;
 
 # Login options specific
-my $o_community = undef;        # community
-my $o_version2  = undef;        #use snmp v2c
-my $o_login     = undef;        # Login for snmpv3
-my $o_passwd    = undef;        # Pass for snmpv3
-my $v3protocols = undef;        # V3 protocol list.
-my $o_authproto = 'md5';        # Auth protocol
-my $o_privproto = 'des';        # Priv protocol
-my $o_privpass  = undef;        # priv password
+my $o_community = undef;            # community
+my $o_version2  = undef;            #use snmp v2c
+my $o_login     = undef;            # Login for snmpv3
+my $o_passwd    = undef;            # Pass for snmpv3
+my $v3protocols = undef;            # V3 protocol list.
+my $o_authproto = 'md5';            # Auth protocol
+my $o_privproto = 'des';            # Priv protocol
+my $o_privpass  = undef;            # priv password
 
 # Readable names for counters (M. Berger contrib)
 my @countername = ("in=", "out=", "errors-in=", "errors-out=", "discard-in=", "discard-out=");
@@ -288,84 +288,84 @@ sub verb { my $t = shift; print $t, "\n" if defined($o_verb); }
 sub check_options {
     Getopt::Long::Configure("bundling");
     GetOptions(
-        'v'             => \$o_verb,
-        'verbose'       => \$o_verb,
-        'h'             => \$o_help,
-        'help'          => \$o_help,
-        'H:s'           => \$o_host,
-        'hostname:s'    => \$o_host,
-        'p:i'           => \$o_port,
-        'port:i'        => \$o_port,
-        'n:s'           => \$o_descr,
-        'name:s'        => \$o_descr,
-        'N'             => \$o_use_ifname,
-        'use-ifname'    => \$o_use_ifname,
-        'A'             => \$o_use_ifalias,
-        'use-ifalias'   => \$o_use_ifalias,
-        'C:s'           => \$o_community,
-        'community:s'   => \$o_community,
-        '2'             => \$o_version2,
-        'v2c'           => \$o_version2,
-        'l:s'           => \$o_login,
-        'login:s'       => \$o_login,
-        'x:s'           => \$o_passwd,
-        'passwd:s'      => \$o_passwd,
-        'X:s'           => \$o_privpass,
-        'privpass:s'    => \$o_privpass,
-        'L:s'           => \$v3protocols,
-        'protocols:s'   => \$v3protocols,
-        't:i'           => \$o_timeout,
-        'timeout:i'     => \$o_timeout,
-        'i'             => \$o_inverse,
-        'inverse'       => \$o_inverse,
-        'a'             => \$o_admin,
-        'admin'         => \$o_admin,
-        'r'             => \$o_noreg,
-        'noregexp'      => \$o_noreg,
-        'V'             => \$o_version,
-        'version'       => \$o_version,
-        'f'             => \$o_perf,
-        'perfparse'     => \$o_perf,
-        'perfdata'      => \$o_perf,
-        'e'             => \$o_perfe,
-        'error'         => \$o_perfe,
-        'k'             => \$o_checkperf,
-        'perfcheck'     => \$o_checkperf,
-        'q'             => \$o_ext_checkperf,
-        'extperfcheck'  => \$o_ext_checkperf,
-        'w:s'           => \$o_warn_opt,
-        'warning:s'     => \$o_warn_opt,
-        'c:s'           => \$o_crit_opt,
-        'critical:s'    => \$o_crit_opt,
-        'B'             => \$o_kbits,
-        'kbits'         => \$o_kbits,
-        's:i'           => \$o_short,
-        'short:i'       => \$o_short,
-        'g'             => \$o_highperf,
-        '64bits'        => \$o_highperf,
-        'S'             => \$o_perfs,
-        'intspeed'      => \$o_perfs,
-        'y'             => \$o_perfp,
-        'perfprct'      => \$o_perfp,
-        'Y'             => \$o_perfr,
-        'perfspeed'     => \$o_perfr,
-        'M'             => \$o_meg,
-        'mega'          => \$o_meg,
-        'G'             => \$o_gig,
-        'giga'          => \$o_gig,
-        'u'             => \$o_prct,
-        'prct'          => \$o_prct,
-        'o:i'           => \$o_octetlength,
-        'octetlength:i' => \$o_octetlength,
-        'label'         => \$o_label,
-        'd:i'           => \$o_delta,
-        'delta:i'       => \$o_delta,
-        'D'             => \$o_dormant,
-        'dormant'       => \$o_dormant,
-        'down'          => \$o_down,
-        'W'             => \$o_weather,
-        'weather'       => \$o_weather,
-        'ign-admindown' => \$o_ignore_admindown,
+        'v'              => \$o_verb,
+        'verbose'        => \$o_verb,
+        'h'              => \$o_help,
+        'help'           => \$o_help,
+        'H:s'            => \$o_host,
+        'hostname:s'     => \$o_host,
+        'p:i'            => \$o_port,
+        'port:i'         => \$o_port,
+        'n:s'            => \$o_descr,
+        'name:s'         => \$o_descr,
+        'N'              => \$o_use_ifname,
+        'use-ifname'     => \$o_use_ifname,
+        'A'              => \$o_use_ifalias,
+        'use-ifalias'    => \$o_use_ifalias,
+        'C:s'            => \$o_community,
+        'community:s'    => \$o_community,
+        '2'              => \$o_version2,
+        'v2c'            => \$o_version2,
+        'l:s'            => \$o_login,
+        'login:s'        => \$o_login,
+        'x:s'            => \$o_passwd,
+        'passwd:s'       => \$o_passwd,
+        'X:s'            => \$o_privpass,
+        'privpass:s'     => \$o_privpass,
+        'L:s'            => \$v3protocols,
+        'protocols:s'    => \$v3protocols,
+        't:i'            => \$o_timeout,
+        'timeout:i'      => \$o_timeout,
+        'i'              => \$o_inverse,
+        'inverse'        => \$o_inverse,
+        'a'              => \$o_admin,
+        'admin'          => \$o_admin,
+        'r'              => \$o_noreg,
+        'noregexp'       => \$o_noreg,
+        'V'              => \$o_version,
+        'version'        => \$o_version,
+        'f'              => \$o_perf,
+        'perfparse'      => \$o_perf,
+        'perfdata'       => \$o_perf,
+        'e'              => \$o_perfe,
+        'error'          => \$o_perfe,
+        'k'              => \$o_checkperf,
+        'perfcheck'      => \$o_checkperf,
+        'q'              => \$o_ext_checkperf,
+        'extperfcheck'   => \$o_ext_checkperf,
+        'w:s'            => \$o_warn_opt,
+        'warning:s'      => \$o_warn_opt,
+        'c:s'            => \$o_crit_opt,
+        'critical:s'     => \$o_crit_opt,
+        'B'              => \$o_kbits,
+        'kbits'          => \$o_kbits,
+        's:i'            => \$o_short,
+        'short:i'        => \$o_short,
+        'g'              => \$o_highperf,
+        '64bits'         => \$o_highperf,
+        'S'              => \$o_perfs,
+        'intspeed'       => \$o_perfs,
+        'y'              => \$o_perfp,
+        'perfprct'       => \$o_perfp,
+        'Y'              => \$o_perfr,
+        'perfspeed'      => \$o_perfr,
+        'M'              => \$o_meg,
+        'mega'           => \$o_meg,
+        'G'              => \$o_gig,
+        'giga'           => \$o_gig,
+        'u'              => \$o_prct,
+        'prct'           => \$o_prct,
+        'o:i'            => \$o_octetlength,
+        'octetlength:i'  => \$o_octetlength,
+        'label'          => \$o_label,
+        'd:i'            => \$o_delta,
+        'delta:i'        => \$o_delta,
+        'D'              => \$o_dormant,
+        'dormant'        => \$o_dormant,
+        'down'           => \$o_down,
+        'W'              => \$o_weather,
+        'weather'        => \$o_weather,
+        'ign-admindown'  => \$o_ignore_admindown,
         'ign-emptyalias' => \$o_ignore_emptyalias,
     );
     if (defined($o_help))    { help();      exit $ERRORS{"UNKNOWN"} }
@@ -656,7 +656,6 @@ if (defined($o_ignore_emptyalias)) {
     }
 }
 
-
 # Select interface by regexp of exact match
 # and put the oid to query in an array
 
@@ -664,20 +663,20 @@ verb("Filter : $o_descr");
 foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
     verb("OID : $key, Desc : $$resultat{$key}");
 
-    my $ignore = 0;
-    my $prefix = $query_table . ".";
+    my $ignore    = 0;
+    my $prefix    = $query_table . ".";
     my ($ifindex) = $key =~ /$prefix(\d+)$/;
 
     # if ign-admindown is set, check the ifIndex against admin status
     if (defined($o_ignore_admindown)) {
-	my $index = $admin_table . "." . $ifindex;
+        my $index     = $admin_table . "." . $ifindex;
         my $admstatus = $$admin_status_table{$index};
         $ignore = 1 if ($admstatus == 2);
     }
 
     # if ign-emptyalias is set, check the ifIndex against alias string
     if (defined($o_ignore_emptyalias)) {
-	my $index = $alias_table . "." . $ifindex;
+        my $index = $alias_table . "." . $ifindex;
         my $alias = $$interfaces_aliases{$index};
         $ignore = 1 if ($alias eq "");
     }
@@ -693,31 +692,36 @@ foreach my $key (sort { $$resultat{$a} cmp $$resultat{$b} } keys %$resultat) {
         my @oid_list = split(/\./, $key);
         my $int_index = pop(@oid_list);
         if (defined($o_noreg) && ($num_int > 0)) {
-            if ($tindex[$num_int-1] < $int_index) {
+            if ($tindex[$num_int - 1] < $int_index) {
                 $num_int = 0;
             }
         }
         if (!defined($o_noreg) || ($num_int == 0)) {
-            $tindex[$num_int] = $int_index; 
+            $tindex[$num_int] = $int_index;
+
             # get the full description
-            $descr[$num_int]=$$resultat{$key};
+            $descr[$num_int] = $$resultat{$key};
+
             # Get rid of special caracters (specially for Windows)
             $descr[$num_int] =~ s/[[:cntrl:]]//g;
-            # put the admin or oper oid in an array
-            $oids[$num_int]= defined ($o_admin) ? $admin_table . "." . $tindex[$num_int]
-			: $oper_table . $tindex[$num_int];
 
-            # Put the performance oid 
+            # put the admin or oper oid in an array
+            $oids[$num_int]
+                = defined($o_admin)
+                ? $admin_table . "." . $tindex[$num_int]
+                : $oper_table . $tindex[$num_int];
+
+            # Put the performance oid
             if (defined($o_perf) || defined($o_checkperf)) {
-                $oid_perf_inoct[$num_int]= $in_octet_table . $tindex[$num_int];
-                $oid_perf_outoct[$num_int]= $out_octet_table . $tindex[$num_int];
-                $oid_speed[$num_int]=$speed_table . $tindex[$num_int];
-                $oid_speed_high[$num_int]=$speed_table_64 . $tindex[$num_int];
+                $oid_perf_inoct[$num_int]  = $in_octet_table . $tindex[$num_int];
+                $oid_perf_outoct[$num_int] = $out_octet_table . $tindex[$num_int];
+                $oid_speed[$num_int]       = $speed_table . $tindex[$num_int];
+                $oid_speed_high[$num_int]  = $speed_table_64 . $tindex[$num_int];
                 if (defined($o_ext_checkperf) || defined($o_perfe)) {
-                    $oid_perf_indisc[$num_int]= $in_discard_table . $tindex[$num_int];
-                    $oid_perf_outdisc[$num_int]= $out_discard_table . $tindex[$num_int];
-                    $oid_perf_inerr[$num_int]= $in_error_table . $tindex[$num_int];
-                    $oid_perf_outerr[$num_int]= $out_error_table . $tindex[$num_int];
+                    $oid_perf_indisc[$num_int]  = $in_discard_table . $tindex[$num_int];
+                    $oid_perf_outdisc[$num_int] = $out_discard_table . $tindex[$num_int];
+                    $oid_perf_inerr[$num_int]   = $in_error_table . $tindex[$num_int];
+                    $oid_perf_outerr[$num_int]  = $out_error_table . $tindex[$num_int];
                 }
             }
             verb("Name : $descr[$num_int], Index : $tindex[$num_int]");
@@ -875,16 +879,20 @@ for (my $i = 0; $i < $num_int; $i++) {
                         if (defined($o_ext_checkperf)) {
                             $checkperf_out[2]
                                 = (($$result{ $oid_perf_inerr[$i] } - $file_values[$j][3])
-                                / ($timenow - $file_values[$j][0])) * 60;
+                                / ($timenow - $file_values[$j][0]))
+                                * 60;
                             $checkperf_out[3]
                                 = (($$result{ $oid_perf_outerr[$i] } - $file_values[$j][4])
-                                / ($timenow - $file_values[$j][0])) * 60;
+                                / ($timenow - $file_values[$j][0]))
+                                * 60;
                             $checkperf_out[4]
                                 = (($$result{ $oid_perf_indisc[$i] } - $file_values[$j][5])
-                                / ($timenow - $file_values[$j][0])) * 60;
+                                / ($timenow - $file_values[$j][0]))
+                                * 60;
                             $checkperf_out[5]
                                 = (($$result{ $oid_perf_outdisc[$i] } - $file_values[$j][6])
-                                / ($timenow - $file_values[$j][0])) * 60;
+                                / ($timenow - $file_values[$j][0]))
+                                * 60;
                         }
                     }
                 }
@@ -1014,11 +1022,13 @@ for (my $i = 0; $i < $num_int; $i++) {
                     } else {                   # just convert from K|M|G bps
                         $warn_factor = (defined($o_meg)) ? 1048576 : (defined($o_gig)) ? 1073741824 : 1024;
                     }
-                    $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_in_Bps'=" . sprintf("%.0f", $checkperf_out_raw[0]) . ";";
+                    $perf_out
+                        .= "'" . $descr[$i] =~ s/\./_/r . "_in_Bps'=" . sprintf("%.0f", $checkperf_out_raw[0]) . ";";
                     $perf_out .= ($o_warn[0] != 0) ? $o_warn[0] * $warn_factor . ";" : ";";
                     $perf_out .= ($o_crit[0] != 0) ? $o_crit[0] * $warn_factor . ";" : ";";
                     $perf_out .= "0;" . $speed_real / 8 . " ";
-                    $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_out_Bps'=" . sprintf("%.0f", $checkperf_out_raw[1]) . ";";
+                    $perf_out
+                        .= "'" . $descr[$i] =~ s/\./_/r . "_out_Bps'=" . sprintf("%.0f", $checkperf_out_raw[1]) . ";";
                     $perf_out .= ($o_warn[1] != 0) ? $o_warn[1] * $warn_factor . ";" : ";";
                     $perf_out .= ($o_crit[1] != 0) ? $o_crit[1] * $warn_factor . ";" : ";";
                     $perf_out .= "0;" . $speed_real / 8 . " ";
@@ -1035,12 +1045,14 @@ for (my $i = 0; $i < $num_int; $i++) {
             $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_out_discard'=" . $$result{ $oid_perf_outdisc[$i] } . "c ";
         }
         if (defined($o_perfs)) {
-	    my $speed_real = "" unless (defined($speed_real));
+            my $speed_real = "" unless (defined($speed_real));
             $perf_out .= "'" . $descr[$i] =~ s/\./_/r . "_speed_bps'=" . $speed_real . " ";
         }
         if (defined($o_weather) && $usable_data == 1) {
-            $perf_out .= "in=" . sprintf("%.0f", $checkperf_out_raw[0]) . ";;;0;" . sprintf("%.0f", $speed_real / 8) . " ";
-            $perf_out .= "out=" . sprintf("%.0f", $checkperf_out_raw[1]) . ";;;0;" . sprintf("%.0f", $speed_real / 8) . " ";
+            $perf_out
+                .= "in=" . sprintf("%.0f", $checkperf_out_raw[0]) . ";;;0;" . sprintf("%.0f", $speed_real / 8) . " ";
+            $perf_out
+                .= "out=" . sprintf("%.0f", $checkperf_out_raw[1]) . ";;;0;" . sprintf("%.0f", $speed_real / 8) . " ";
         }
     }
 }


### PR DESCRIPTION
Added two new options to check_snmp_int.pl, which allow to exclude from monitoring interfaces by the following criteria:
--ign-admindown: Ignore interfaces in Admin down state
--ign-emptyalias: Ignore interfaces having empty alias (port description)

Also, fixed the warning like:
`Use of uninitialized value $speed_real in concatenation (.) or string at ./check_snmp_int_new.pl line 979`
wheb the interface speed is not set (e.g. port transceiver is absent).